### PR TITLE
Convert apat/gh-migration to GitHub Actions

### DIFF
--- a/.github/workflows/gh-migration.yml
+++ b/.github/workflows/gh-migration.yml
@@ -1,0 +1,34 @@
+name: apat/gh-migration
+on:
+  push:
+jobs:
+  Build-Stage-checkout:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        clean: false
+    - run: echo "hi"
+    - uses: actions/checkout@v4.1.0
+      env:
+        REPO_NAME: "**org/name**"
+      with:
+        repository: "${{ env.REPO_NAME }}"
+        clean: false
+  Security-Stage-security-scan:
+    runs-on: ubuntu-latest
+    needs:
+    - Build-Stage-checkout
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        clean: false
+  Deploy-Stage-deploy-e1:
+    runs-on: ubuntu-latest
+    needs:
+    - Build-Stage-checkout
+    - Security-Stage-security-scan
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        clean: false


### PR DESCRIPTION
Pipeline migrated from [Bamboo](https://bamboo.shared-private.opsera.io) :tada:

## Manual steps

Perform the following steps to complete the migration:

### apat/gh-migration
- [x] Ensure: ${{ env.REPO_NAME }} is set to the correct org/name of the GitHub repository for 'ssh-repo2'